### PR TITLE
Added support for negative progress

### DIFF
--- a/lib/src/radial_gauge/data/gauge_axis.dart
+++ b/lib/src/radial_gauge/data/gauge_axis.dart
@@ -69,6 +69,11 @@ class GaugeAxis extends Equatable {
   /// Defaults to 1.0. Must be greater than [min].
   final double max;
 
+  /// The zero value the gauge can display.
+  ///
+  /// Defaults to 0.0. Must be greater or equal to [min].
+  final double zero;
+
   /// Determines the degree of arc of the gauge axis.
   ///
   /// Defaults to 180.
@@ -112,6 +117,7 @@ class GaugeAxis extends Equatable {
   const GaugeAxis({
     this.min = 0.0,
     this.max = 1.0,
+    this.zero = 0.0,
     this.transformer = const GaugeAxisTransformer.noTransform(),
     this.segments = const [],
     this.degrees = 180,
@@ -140,10 +146,12 @@ class GaugeAxis extends Equatable {
     final double? degrees,
     final double? min,
     final double? max,
+    final double? zero,
   }) =>
       GaugeAxis(
         min: min ?? this.min,
         max: max ?? this.max,
+        zero: zero ?? this.zero,
         degrees: degrees ?? this.degrees,
         segments: segments ?? this.segments,
         style: style ?? this.style,

--- a/lib/src/radial_gauge/progress_bar/gauge_basic_progress_bar.dart
+++ b/lib/src/radial_gauge/progress_bar/gauge_basic_progress_bar.dart
@@ -26,10 +26,12 @@ class GaugeBasicProgressBar extends Equatable implements GaugeProgressBar {
     GaugeAxis axis,
     RadialGaugeLayout layout,
     Canvas canvas,
+    double from,
     double progress,
   ) {
     final progressBar = calculateAxisPath(
       layout.circleRect,
+      from: from,
       to: progress,
       degrees: axis.degrees,
       thickness: axis.style.thickness,

--- a/lib/src/radial_gauge/progress_bar/gauge_progress.dart
+++ b/lib/src/radial_gauge/progress_bar/gauge_progress.dart
@@ -22,6 +22,7 @@ abstract class GaugeProgressBar {
     GaugeAxis axis,
     RadialGaugeLayout layout,
     Canvas canvas,
+    double from,
     double progress,
   );
 

--- a/lib/src/radial_gauge/progress_bar/gauge_rounded_progress_bar.dart
+++ b/lib/src/radial_gauge/progress_bar/gauge_rounded_progress_bar.dart
@@ -26,10 +26,12 @@ class GaugeRoundedProgressBar extends Equatable implements GaugeProgressBar {
     GaugeAxis axis,
     RadialGaugeLayout layout,
     Canvas canvas,
+    double from,
     double progress,
   ) {
     final progressBar = calculateRoundedArcPath(
       layout.circleRect,
+      from: from,
       to: progress,
       degrees: axis.degrees,
       thickness: axis.style.thickness,

--- a/lib/src/radial_gauge/widgets/radial_gauge_render_box.dart
+++ b/lib/src/radial_gauge/widgets/radial_gauge_render_box.dart
@@ -18,7 +18,9 @@ import '../internal/radial_gauge_size_ratios.dart';
 class RadialGaugeRenderBox extends RenderShiftedBox {
   /// Current value of the radial gauge
   double _value;
+
   double get value => _value;
+
   set value(double value) {
     if (_value != value) {
       _value = value;
@@ -30,6 +32,7 @@ class RadialGaugeRenderBox extends RenderShiftedBox {
   /// Only a single axis is supported
   GaugeAxis get axis => _axis;
   GaugeAxis _axis;
+
   set axis(GaugeAxis axis) {
     if (_axis != axis) {
       if (_axis.degrees != axis.degrees ||
@@ -44,7 +47,9 @@ class RadialGaugeRenderBox extends RenderShiftedBox {
   }
 
   Alignment _alignment;
+
   Alignment get alignment => _alignment;
+
   set alignment(Alignment alignment) {
     if (_alignment != alignment) {
       _alignment = alignment;
@@ -53,7 +58,9 @@ class RadialGaugeRenderBox extends RenderShiftedBox {
   }
 
   double? _radius;
+
   double? get radius => _radius;
+
   set radius(double? radius) {
     if (_radius != radius) {
       _radius = radius;
@@ -62,7 +69,9 @@ class RadialGaugeRenderBox extends RenderShiftedBox {
   }
 
   bool _debug;
+
   bool get debug => _debug;
+
   set debug(bool debug) {
     if (_debug != debug) {
       _debug = debug;
@@ -92,6 +101,8 @@ class RadialGaugeRenderBox extends RenderShiftedBox {
   bool get sizedByParent => false;
 
   double get _valueProgress => (value - axis.min) / (axis.max - axis.min);
+
+  double get _from => (axis.zero - axis.min) / (axis.max - axis.min);
 
   @override
   void performLayout() {
@@ -220,7 +231,7 @@ class RadialGaugeRenderBox extends RenderShiftedBox {
 
     if (progressBar != null &&
         progressBar.placement == GaugeProgressPlacement.inside) {
-      progressBar.paint(axis, layout, canvas, _valueProgress);
+      progressBar.paint(axis, layout, canvas, _from, _valueProgress);
     }
 
     for (var i = 0; i < axisDefinition.segments.length; i++) {
@@ -237,7 +248,7 @@ class RadialGaugeRenderBox extends RenderShiftedBox {
 
     if (progressBar != null &&
         progressBar.placement == GaugeProgressPlacement.over) {
-      progressBar.paint(axis, layout, canvas, _valueProgress);
+      progressBar.paint(axis, layout, canvas, _from, _valueProgress);
     }
 
     canvas.restore();

--- a/lib/src/utils/calculate_axis_path.dart
+++ b/lib/src/utils/calculate_axis_path.dart
@@ -8,8 +8,6 @@ Path calculateAxisPath(
   double degrees = 180.0,
   double thickness = 10.0,
 }) {
-  assert(from <= to, 'Cannot draw inverted arc.');
-
   final radius = rect.longestSide / 2;
 
   degrees = (degrees).clamp(10.0, 359.99);
@@ -55,6 +53,7 @@ Path calculateAxisPath(
       endOuterPoint,
       largeArc: useDegrees > largeArcMinAngle,
       radius: Radius.circular(outerRadius),
+      clockwise: from < to,
     )
     ..lineTo(
       endInnerPoint.dx,
@@ -64,7 +63,7 @@ Path calculateAxisPath(
       startInnerPoint,
       largeArc: useDegrees > largeArcMinAngle,
       radius: Radius.circular(innerRadius),
-      clockwise: false,
+      clockwise: from > to,
     )
     ..lineTo(
       startOuterPoint.dx,

--- a/lib/src/utils/calculate_rounded_path.dart
+++ b/lib/src/utils/calculate_rounded_path.dart
@@ -8,8 +8,6 @@ Path calculateRoundedArcPath(
   double degrees = 180.0,
   double thickness = 10.0,
 }) {
-  assert(from <= to, 'Cannot draw inverted arc.');
-
   final radius = rect.longestSide / 2;
 
   degrees = (degrees).clamp(10.0, 359.99);
@@ -37,8 +35,10 @@ Path calculateRoundedArcPath(
   final cornerAngle = getArcAngle(halfThickness, centerRadius);
   final largeArcMinAngle = 180.0 + toDegrees(cornerAngle * 2);
 
-  final axisStartAngle = toRadians(startAngle) + cornerAngle;
-  final axisEndAngle = toRadians(endAngle) - cornerAngle;
+  final axisStartAngle =
+      toRadians(startAngle) + (from > to ? -cornerAngle : cornerAngle);
+  final axisEndAngle =
+      toRadians(endAngle) - (from > to ? -cornerAngle : cornerAngle);
 
   final startOuterPoint =
       getPointOnCircle(circleCenter, axisStartAngle, outerRadius);
@@ -50,25 +50,31 @@ Path calculateRoundedArcPath(
       getPointOnCircle(circleCenter, axisStartAngle, innerRadius);
 
   final axisSurface = Path()
-    ..moveTo(startOuterPoint.dx, startOuterPoint.dy)
+    ..moveTo(
+      startOuterPoint.dx,
+      startOuterPoint.dy,
+    )
     ..arcToPoint(
       endOuterPoint,
       largeArc: useDegrees > largeArcMinAngle,
       radius: Radius.circular(outerRadius),
+      clockwise: from < to,
     )
     ..arcToPoint(
       endInnerPoint,
       radius: Radius.circular(halfThickness),
+      clockwise: from < to,
     )
     ..arcToPoint(
       startInnerPoint,
       largeArc: useDegrees > largeArcMinAngle,
       radius: Radius.circular(innerRadius),
-      clockwise: false,
+      clockwise: from > to,
     )
     ..arcToPoint(
       startOuterPoint,
       radius: Radius.circular(halfThickness),
+      clockwise: from < to,
     );
 
   return axisSurface;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: gauge_indicator
 description: An animated, highly customizable, open source, Flutter gauge widget.
-version: 0.4.3
+version: 0.4.4
 homepage: https://github.com/gonuit/gauge_indicator
 
 environment:


### PR DESCRIPTION
Currently, the gauge supports negative values, but it starts from the left (min) point. I have added support for the zero point. With this property, the gauge will now have three bounds: the existing `minimum` and `maximum` values, and a new `zero` point, which represents the middle position. This property allows us to set a middle value from which our progress will be displayed. It works for different values, but `zero` should belong to the range from `min` to `max` value (inclusive).

Please see attached screenshots:

<img width="318" alt="image" src="https://github.com/gonuit/gauge_indicator/assets/143705486/fe02e8fb-f2a3-45b1-923a-27f74774dc09">
<img width="318" alt="image" src="https://github.com/gonuit/gauge_indicator/assets/143705486/a2aea87b-4dc9-44e0-bb7e-04718f48a403">
<img width="318" alt="image" src="https://github.com/gonuit/gauge_indicator/assets/143705486/3a382917-4003-4935-9a3b-b0cd65888427">
